### PR TITLE
Remove space from registry arg.

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -36,7 +36,7 @@ if (threshold === -1) {
 var command = 'npm';
 var command_args = ['audit', '--json'];
 if ( registry !== null ) {
-  command_args.push(' --registry=' + registry);
+  command_args.push('--registry=' + registry);
 }
 
 var stdout = '';


### PR DESCRIPTION
# Resolves #43 (REQUIRED)

# Description
Removes a space that causes the command to fail when attempting to pass a registry argument. This bug was introduced int his commit: https://github.com/InfoSec812/npm-audit-ci-wrapper/commit/0301d2253afc5484e1c8f4807cec38f5b2e8701e
